### PR TITLE
Fixes for issues #4 and #5

### DIFF
--- a/macOSLAPS/ADTools.swift
+++ b/macOSLAPS/ADTools.swift
@@ -41,19 +41,27 @@ func connect_to_ad() -> Array<ODRecord> {
 func ad_tools(computer_record: Array<ODRecord>, tool: String, password: String?, new_ad_exp_date: String?) -> String? {
     for case let value in computer_record {
         if tool == "Expiration Time" {
-            var expirationtime = try! String(describing: value.values(forAttribute: "dsAttrTypeNative:ms-Mcs-AdmPwdExpirationTime")[0])
-            if !expirationtime.isEmpty {
-                return(expirationtime)
-            }
-            else {
+            var expirationtime = "126227988000000000" // Setting a default expiration date of 01/01/2001
+            do {
+                expirationtime = try String(describing: value.values(forAttribute: "dsAttrTypeNative:ms-Mcs-AdmPwdExpirationTime")[0])
+            } catch {
                 laps_log.print("There has never been a random password generated for this device. Setting a default expiration date of 01/01/2001 in Active Directory to force a password change...", .warn)
-                expirationtime = "126227988000000000"
-                return(expirationtime)
             }
+            return(expirationtime)
         }
+
         if tool == "Set Password" {
-            try! value.setValue(password, forAttribute: "dsAttrTypeNative:ms-Mcs-AdmPwd")
-            try! value.setValue(new_ad_exp_date, forAttribute: "dsAttrTypeNative:ms-Mcs-AdmPwdExpirationTime")
+            do {
+                try value.setValue(password, forAttribute: "dsAttrTypeNative:ms-Mcs-AdmPwd")
+            } catch {
+                laps_log.print("There was an error setting the password for this device...", .warn)
+            }
+            
+            do {
+                try value.setValue(new_ad_exp_date, forAttribute: "dsAttrTypeNative:ms-Mcs-AdmPwdExpirationTime")
+            } catch {
+                laps_log.print("There was an error setting the new password expiration for this device...", .warn)
+            }
         }
     }
     return(nil)

--- a/macOSLAPS/PWChange.swift
+++ b/macOSLAPS/PWChange.swift
@@ -13,8 +13,8 @@ func perform_password_change(computer_record: Array<ODRecord>, local_admin: Stri
     laps_log.print("Password Change is required as the LAPS password for " + local_admin + " has expired", .info)
     // Get our configuration variables to prepare for password change
     
-    let pass_length = get_config_settings(preference_key: "PasswordLength") as! Int
-    let exp_days = get_config_settings(preference_key: "DaysTillExpiration") as! Int
+    let pass_length = Int(get_config_settings(preference_key: "PasswordLength") as! Int)
+    let exp_days = Int(get_config_settings(preference_key: "DaysTillExpiration") as! Int)
     let keychain_remove = get_config_settings(preference_key: "RemoveKeychain") as! Bool
     
     // Generate random password

--- a/macOSLAPS/PWChange.swift
+++ b/macOSLAPS/PWChange.swift
@@ -12,9 +12,11 @@ import OpenDirectory
 func perform_password_change(computer_record: Array<ODRecord>, local_admin: String) {
     laps_log.print("Password Change is required as the LAPS password for " + local_admin + " has expired", .info)
     // Get our configuration variables to prepare for password change
+    
     let pass_length = get_config_settings(preference_key: "PasswordLength") as! Int
     let exp_days = get_config_settings(preference_key: "DaysTillExpiration") as! Int
     let keychain_remove = get_config_settings(preference_key: "RemoveKeychain") as! Bool
+    
     // Generate random password
     let password = generate_random_pw(length: pass_length)
     do {


### PR DESCRIPTION
Put expiration Time in a do-catch block. This fixes an issue where getting the expiration time from AD where that value was nill would cause cause the try! to fail and since there was no catch, the program would crash

also wrap reading from pass_length and exp_days in an Int() to cover cases where these values were being read in as string