### PR TITLE
Change LD to run every 90 minutes and update README.md to define preference formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ the character map to enter it. Since this is very detriment to using a LAPS pass
 
 Installation Instructions
 -------------------------
-At this time you can clone the repo or download a zip of the repo or you can
-use the package created using Packages to install. This script will run
-3 times a day between 8 A.M. and 5 P.M. at 9 A.M., 1 P.M. and 4 P.M.
+At this time you can clone the repo or download a zip of the repo or you can use the package created using Packages to install. The package includes a Launch Daemon to run macOSLAPS every 90 minutes.
 
 Logging
 -------

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Requirements
 
 The following parameters must be set or the application will use the defaults:
 
-**LocalAdminAccount** - Local Administrator Account. Default is 'admin'  
-**DaysTillExpiration** - Expiration date of random password. Default is 60 Days  
-**PasswordLength** - Length of randomly generated password. Default is 12  
-**RemoveKeyChain** - Remove the local admin keychains after password change. (Recommended)  
+**LocalAdminAccount** - Local Administrator Account. Default is 'admin'. (In String format)  
+**DaysTillExpiration** - Expiration date of random password. Default is 60 Days. (In Integer format)  
+**PasswordLength** - Length of randomly generated password. Default is 12. (In Integer format)
+**RemoveKeyChain** - Remove the local admin keychains after password change. (In Boolean format, recommended)  
 **RemovePassChars** - Exclude any characters you'd like from the randomly generated password (In String format)
 **ExclusionSets** - Exclude any character set you'd like by specificying a string in an array (Example: "symbols")
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The following parameters must be set or the application will use the defaults:
 
 **LocalAdminAccount** - Local Administrator Account. Default is 'admin'. (In String format)  
 **DaysTillExpiration** - Expiration date of random password. Default is 60 Days. (In Integer format)  
-**PasswordLength** - Length of randomly generated password. Default is 12. (In Integer format) . 
-**RemoveKeyChain** - Remove the local admin keychains after password change. (In Boolean format, recommended)  
+**PasswordLength** - Length of randomly generated password. Default is 12. (In Integer format)  
+**RemoveKeyChain** - Remove the local admin keychains after password change. (In Boolean format, recommended)  
 **RemovePassChars** - Exclude any characters you'd like from the randomly generated password (In String format)  
 **ExclusionSets** - Exclude any character set you'd like by specificying a string in an array (Example: "symbols")  
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Requirements
 
 The following parameters must be set or the application will use the defaults:
 
-**LocalAdminAccount** - Local Administrator Account. Default is 'admin'. (In String format)
-**DaysTillExpiration** - Expiration date of random password. Default is 60 Days. (In Integer format)
-**PasswordLength** - Length of randomly generated password. Default is 12. (In Integer format)
-**RemoveKeyChain** - Remove the local admin keychains after password change. (In Boolean format, recommended)
-**RemovePassChars** - Exclude any characters you'd like from the randomly generated password (In String format)
-**ExclusionSets** - Exclude any character set you'd like by specificying a string in an array (Example: "symbols")
+**LocalAdminAccount** - Local Administrator Account. Default is 'admin'. (In String format)  
+**DaysTillExpiration** - Expiration date of random password. Default is 60 Days. (In Integer format)  
+**PasswordLength** - Length of randomly generated password. Default is 12. (In Integer format) . 
+**RemoveKeyChain** - Remove the local admin keychains after password change. (In Boolean format, recommended)  
+**RemovePassChars** - Exclude any characters you'd like from the randomly generated password (In String format)  
+**ExclusionSets** - Exclude any character set you'd like by specificying a string in an array (Example: "symbols")  
 
 These parameters are set in the location /Libary/Preferences/edu.psu.macoslaps.plist
 or you can use your MDM's Custom Settings to set these values.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Requirements
 
 The following parameters must be set or the application will use the defaults:
 
-**LocalAdminAccount** - Local Administrator Account. Default is 'admin'. (In String format)  
-**DaysTillExpiration** - Expiration date of random password. Default is 60 Days. (In Integer format)  
+**LocalAdminAccount** - Local Administrator Account. Default is 'admin'. (In String format)
+**DaysTillExpiration** - Expiration date of random password. Default is 60 Days. (In Integer format)
 **PasswordLength** - Length of randomly generated password. Default is 12. (In Integer format)
-**RemoveKeyChain** - Remove the local admin keychains after password change. (In Boolean format, recommended)  
+**RemoveKeyChain** - Remove the local admin keychains after password change. (In Boolean format, recommended)
 **RemovePassChars** - Exclude any characters you'd like from the randomly generated password (In String format)
 **ExclusionSets** - Exclude any character set you'd like by specificying a string in an array (Example: "symbols")
 

--- a/edu.psu.macoslaps-check.plist
+++ b/edu.psu.macoslaps-check.plist
@@ -8,26 +8,7 @@
   <array>
     <string>/usr/local/laps/macOSLAPS</string>
   </array>
-  <key>StartCalendarInterval</key>
-  <array>
-    <dict>
-      <key>Minute</key>
-      <integer>0</integer>
-      <key>Hour</key>
-      <integer>9</integer>
-    </dict>
-    <dict>
-      <key>Minute</key>
-      <integer>0</integer>
-      <key>Hour</key>
-      <integer>13</integer>
-    </dict>
-    <dict>
-      <key>Minute</key>
-      <integer>0</integer>
-      <key>Hour</key>
-      <integer>16</integer>
-    </dict>
-  </array>
+  <key>StartInterval</key>
+  <integer>5400</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Suggested change of running macOSLAPS every 90 minutes - this follows the default CSE/GPO behaviour on Windows and means more chance of catching Macs that are used infrequently/shutdown a lot like laptops.