### PR TITLE
Change date format to ISO8601

### DIFF
--- a/macOSLAPS.xcodeproj/project.pbxproj
+++ b/macOSLAPS.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-sectcreate",
@@ -354,7 +354,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-sectcreate",
@@ -509,7 +509,7 @@
 				GENERATE_PKGINFO_FILE = NO;
 				INFOPLIST_FILE = "$(SRCROOT)/macOSLAPS/Info.plist";
 				INSTALL_PATH = /usr/local/laps;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MARKETING_VERSION = 2.0.0;
 				ONLY_ACTIVE_ARCH = NO;
 				"OTHER_LDFLAGS[arch=*]" = (
@@ -536,7 +536,7 @@
 				GENERATE_PKGINFO_FILE = NO;
 				INFOPLIST_FILE = "$(SRCROOT)/macOSLAPS/Info.plist";
 				INSTALL_PATH = /usr/local/laps;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MARKETING_VERSION = 2.0.0;
 				ONLY_ACTIVE_ARCH = NO;
 				"OTHER_LDFLAGS[arch=*]" = (

--- a/macOSLAPS/Extensions/DateFormatter.swift
+++ b/macOSLAPS/Extensions/DateFormatter.swift
@@ -10,8 +10,7 @@ import Foundation
 
 
 // Used to format the date when needed
-func date_formatter () -> DateFormatter {
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "E MMM dd, yyyy hh:mm:ss a"
+func date_formatter () -> ISO8601DateFormatter {
+    let dateFormatter = ISO8601DateFormatter()
     return(dateFormatter)
 }


### PR DESCRIPTION
Also changes the deployment target to 10.12. If you want to stay on 10.10, see https://stackoverflow.com/questions/16254575/how-do-i-get-an-iso-8601-date-on-ios