### PR TITLE
incorporation of LAPS and legacy LAPS

### DIFF
--- a/macOSLAPS/Password Tools/ADPasswordTools.swift
+++ b/macOSLAPS/Password Tools/ADPasswordTools.swift
@@ -57,7 +57,7 @@ public class ADTools: NSObject {
         var laps_schema_type = ""
         do {
             _ = try computer_record[0].values(forAttribute: "dsAttrTypeNative:ms-Mcs-AdmPwdExpirationTime")[0]
-            laps_schema_type = "Windows LAPS schema element"
+            laps_schema_type = "Legacy Microsoft LAPS schema element"
         } catch {
             laps_log.print("Attribute ms-Mcs-AdmPwdExpirationTime not found, probing for msLAPS-PasswordExpirationTime...", .warn)
         }


### PR DESCRIPTION
All changes affect only the AD mode part of macOSLAPS.
Supported are now the newer Attributes of LAPS ("msLAPS-Password" and "msLAPS-PasswordExpirationTime") and script stops if no AD LAPS schema is detected.